### PR TITLE
Allow superuser to claim any unclaimed device

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,11 +10,13 @@ class TestCase(djangoTestCase):
     # Some test users
     USER_1: str = "testuser1"
     USER_2: str = "testuser2"
+    ADMIN_1: str = "admin1"
 
     # Some test devices
     DEVICE_1: str = "00:00:00:00:00:00"
     DEVICE_2: str = "11:11:11:11:11:11"
     DEVICE_3: str = "22:22:22:22:22:22"
+    REMOTE_DEVICE_1: str = "33:33:33:33:33:33"
 
     # The initial runreq auto-ids installed by fixtures
     RUNREQ_INSTALLED = "fedora-installed"
@@ -28,6 +30,14 @@ class TestCase(djangoTestCase):
             models.Device(
                 mac_address=macaddr, architecture="x86_64", last_ip_address="127.0.0.1"
             ).save()
+
+        models.Device(
+            mac_address=cls.REMOTE_DEVICE_1,
+            architecture="x86_64",
+            last_ip_address="10.10.10.10",
+        ).save()
+
+        User.objects.create_superuser(cls.ADMIN_1, password="testpass")
 
         for username in (cls.USER_1, cls.USER_2):
             User.objects.create_user(username, password="testpass")

--- a/tests/test_views_portal_devices.py
+++ b/tests/test_views_portal_devices.py
@@ -19,6 +19,12 @@ class PortalDevicesTest(TestCase):
             resp = self.client.get("/portal/claim/")
             self.assertTemplateUsed(resp, "portal/claim.html")
             self.assertEqual(len(resp.context["unclaimed_devices"]), 3)
+            self.assertNotContains(resp, self.REMOTE_DEVICE_1)
+        with self.loggedin_as(self.ADMIN_1):
+            resp = self.client.get("/portal/claim/")
+            self.assertTemplateUsed(resp, "portal/claim.html")
+            self.assertEqual(len(resp.context["unclaimed_devices"]), 4)
+            self.assertContains(resp, self.REMOTE_DEVICE_1)
 
     def test_claim_device(self):
         with self.loggedin_as():

--- a/zezere/templates/portal/claim.html
+++ b/zezere/templates/portal/claim.html
@@ -5,7 +5,11 @@
 {% block title %}Claim unowned devices{% endblock %}
 
 {% block content %}
+{% if super %}
+Unowned devices:
+{% else %}
 Unowned devices from this IP address:
+{% endif %}
 {% for device in unclaimed_devices %}
     {% has_perm 'zezere.claim_device' user device as can_claim_device %}
     {% if can_claim_device %}

--- a/zezere/views_portal.py
+++ b/zezere/views_portal.py
@@ -28,12 +28,12 @@ def claim(request):
             device.save()
         return redirect("/portal/claim/")
 
-    remote_ip, _ = get_client_ip(request)
-    context = {
-        "unclaimed_devices": Device.objects.filter(
-            owner__isnull=True, last_ip_address=remote_ip
-        )
-    }
+    if request.user.is_superuser:
+        unclaimed = Device.objects.filter(owner__isnull=True)
+    else:
+        remote_ip, _ = get_client_ip(request)
+        unclaimed = Device.objects.filter(owner__isnull=True, last_ip_address=remote_ip)
+    context = {"unclaimed_devices": unclaimed, "super": request.user.is_superuser}
     return render(request, "portal/claim.html", context)
 
 


### PR DESCRIPTION
Well, *display* all unclaimed devices to superusers, anyway. In
fact anyone can already claim any device they know the MAC
address of, but we don't show in the web UI.

Signed-off-by: Adam Williamson <awilliam@redhat.com>